### PR TITLE
making standalone dynamixel control instead of a Dynamixel sub-repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "DynamixelSDK"]
-	path = DynamixelSDK
-	url = https://github.com/ROBOTIS-GIT/DynamixelSDK.git

--- a/dynamixel_control/dynamixel_control/CMakeLists.txt
+++ b/dynamixel_control/dynamixel_control/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.8)
+project(dynamixel_control)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# Find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(dynamixel_sdk REQUIRED)
+find_package(dynamixel_sdk_custom_interfaces REQUIRED)
+find_package(dynamixel_control_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+
+include_directories(include)
+
+# Build
+add_executable(motor_interface src/motor_interface.cpp)
+ament_target_dependencies(motor_interface
+  dynamixel_sdk_custom_interfaces
+  dynamixel_control_msgs
+  dynamixel_sdk
+  rclcpp
+)
+
+# Install
+install(TARGETS
+  motor_interface
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/dynamixel_control/dynamixel_control/include/motor_interface.hpp
+++ b/dynamixel_control/dynamixel_control/include/motor_interface.hpp
@@ -1,0 +1,36 @@
+#ifndef READ_WRITE_NODE_HPP_
+#define READ_WRITE_NODE_HPP_
+
+#include <cstdio>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcutils/cmdline_parser.h"
+#include "dynamixel_sdk/dynamixel_sdk.h"
+#include "dynamixel_sdk_custom_interfaces/msg/set_position.hpp"
+#include "dynamixel_control_msgs/srv/set_operating_mode.hpp"
+
+class ReadWriteNode : public rclcpp::Node
+{
+public:
+  using SetPosition = dynamixel_sdk_custom_interfaces::msg::SetPosition;
+  using GetPosition = dynamixel_sdk_custom_interfaces::srv::GetPosition;
+  using SetOperatingMode = dynamixel_control_msgs::srv::SetOperatingMode;
+
+  ReadWriteNode();
+  virtual ~ReadWriteNode();
+
+private:
+  void updateGoalCurrent();
+
+  rclcpp::Subscription<SetPosition>::SharedPtr set_position_subscriber_;
+  rclcpp::Service<SetOperatingMode>::SharedPtr set_operating_mode_service_;
+  rclcpp::Service<GetPosition>::SharedPtr get_position_server_;
+
+  int present_position;
+  int goal_current;
+  // rclcpp::TimerBase::SharedPtr goal_current_timer;
+};
+
+#endif  // READ_WRITE_NODE_HPP_

--- a/dynamixel_control/dynamixel_control/package.xml
+++ b/dynamixel_control/dynamixel_control/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>dynamixel_control</name>
+  <version>0.0.0</version>
+  <description>Dynamixel Gripper Control</description>
+  <maintainer email="rosettem@oregonstate.edu">marcus</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>dynamixel_sdk</depend>
+  <depend>dynamixel_sdk_custom_interfaces</depend>
+  <depend>dynamixel_control_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/dynamixel_control/dynamixel_control/src/motor_interface.cpp
+++ b/dynamixel_control/dynamixel_control/src/motor_interface.cpp
@@ -1,0 +1,287 @@
+// Code modified from ROBOTIS dynamixel_sdk_examples read_write_node.cpp
+
+#include <cstdio>
+#include <memory>
+#include <string>
+
+// #include "dynamixel_sdk/dynamixel_sdk.h"
+#include "dynamixel_sdk_custom_interfaces/msg/set_position.hpp"
+#include "dynamixel_sdk_custom_interfaces/srv/get_position.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rcutils/cmdline_parser.h"
+
+#include "motor_interface.hpp"
+
+// Control table address for X series (except XL-320)
+#define ADDR_OPERATING_MODE 11
+#define ADDR_TORQUE_ENABLE 64
+#define ADDR_GOAL_POSITION 116
+#define ADDR_PRESENT_POSITION 132
+#define ADDR_GOAL_CURRENT 102
+
+// Protocol version
+#define PROTOCOL_VERSION 2.0  // Default Protocol version of DYNAMIXEL X series.
+
+// Default setting
+#define BAUDRATE 57600  // Default Baudrate of DYNAMIXEL X series
+#define DEVICE_NAME "/dev/ttyUSB0"  // [Linux]: "/dev/ttyUSB*", [Windows]: "COM*"
+
+dynamixel::PortHandler * portHandler;
+dynamixel::PacketHandler * packetHandler;
+
+uint8_t dxl_error = 0;
+uint32_t goal_position = 0;
+int dxl_comm_result = COMM_TX_FAIL;
+
+ReadWriteNode::ReadWriteNode()
+: Node("read_write_node")
+{
+  RCLCPP_INFO(this->get_logger(), "Run read write node");
+
+  this->declare_parameter("qos_depth", 10);
+  int8_t qos_depth = 0;
+  this->get_parameter("qos_depth", qos_depth);
+
+  const auto QOS_RKL10V =
+    rclcpp::QoS(rclcpp::KeepLast(qos_depth)).reliable().durability_volatile();
+
+  // this->declare_parameter<int>("goal_current", 10);
+  // this->get_parameter("goal_current", goal_current);
+
+  // // Create a timer to continuously check for parameter updates
+  // goal_current_timer = this->create_wall_timer(
+  //     std::chrono::seconds(1), std::bind(&ReadWriteNode::updateGoalCurrent, this));
+
+  set_position_subscriber_ =
+    this->create_subscription<SetPosition>(
+    "set_position",
+    QOS_RKL10V,
+    [this](const SetPosition::SharedPtr msg) -> void
+    {
+      uint8_t dxl_error = 0;
+
+      // Position Value of X series is 4 byte data.
+      // For AX & MX(1.0) use 2 byte data(uint16_t) for the Position Value.
+      uint32_t goal_position = (unsigned int)msg->position;  // Convert int32 -> uint32
+
+      // Write Goal Position (length : 4 bytes)
+      // When writing 2 byte data to AX / MX(1.0), use write2ByteTxRx() instead.
+      dxl_comm_result =
+      packetHandler->write4ByteTxRx(
+        portHandler,
+        (uint8_t) msg->id,
+        ADDR_GOAL_POSITION,
+        goal_position,
+        &dxl_error
+      );
+
+      if (dxl_comm_result != COMM_SUCCESS) {
+        RCLCPP_INFO(this->get_logger(), "%s", packetHandler->getTxRxResult(dxl_comm_result));
+      } else if (dxl_error != 0) {
+        RCLCPP_INFO(this->get_logger(), "%s", packetHandler->getRxPacketError(dxl_error));
+      } else {
+        RCLCPP_INFO(this->get_logger(), "Set [ID: %d] [Goal Position: %d]", msg->id, msg->position);
+      }
+    }
+    );
+
+  auto get_present_position =
+    [this](
+    const std::shared_ptr<GetPosition::Request> request,
+    std::shared_ptr<GetPosition::Response> response) -> void
+    {
+      // Read Present Position (length : 4 bytes) and Convert uint32 -> int32
+      // When reading 2 byte data from AX / MX(1.0), use read2ByteTxRx() instead.
+      dxl_comm_result = packetHandler->read4ByteTxRx(
+        portHandler,
+        (uint8_t) request->id,
+        ADDR_PRESENT_POSITION,
+        reinterpret_cast<uint32_t *>(&present_position),
+        &dxl_error
+      );
+
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Get [ID: %d] [Present Position: %d]",
+        request->id,
+        present_position
+      );
+
+      response->position = present_position;
+    };
+
+  get_position_server_ = create_service<GetPosition>("get_position", get_present_position);
+
+  auto set_operating_mode_callback =
+    [this](
+    const std::shared_ptr<SetOperatingMode::Request> request,
+    std::shared_ptr<SetOperatingMode::Response> response) -> void
+    {
+      uint8_t dxl_error = 0;
+      uint8_t dxl_id = request->id;
+      uint8_t operating_mode = request->operating_mode;
+      uint32_t operation_target = request->operation_target;
+
+      // Disable Torque of DYNAMIXEL
+      dxl_comm_result = packetHandler->write1ByteTxRx(
+        portHandler,
+        dxl_id,
+        ADDR_TORQUE_ENABLE,
+        0,
+        &dxl_error
+      );
+
+      // Write Operating Mode (length : 1 byte)
+      dxl_comm_result = packetHandler->write1ByteTxRx(
+        portHandler,
+        dxl_id,
+        ADDR_OPERATING_MODE,
+        operating_mode,
+        &dxl_error
+      );
+
+      // Enable Torque of DYNAMIXEL
+      dxl_comm_result = packetHandler->write1ByteTxRx(
+        portHandler,
+        dxl_id,
+        ADDR_TORQUE_ENABLE,
+        1,
+        &dxl_error
+      );
+
+      if (operating_mode == 0) {
+        // Set goal current of DYNAMIXEL
+        dxl_comm_result = packetHandler->write2ByteTxRx(
+          portHandler,
+          dxl_id,
+          ADDR_GOAL_CURRENT,
+          operation_target,
+          &dxl_error
+        );
+      }
+
+      if (operating_mode == 3) {
+        // Write Goal Position (length : 4 bytes)
+        // When writing 2 byte data to AX / MX(1.0), use write2ByteTxRx() instead.
+        dxl_comm_result = packetHandler->write4ByteTxRx(
+          portHandler,
+          dxl_id,
+          ADDR_GOAL_POSITION,
+          operation_target,
+          &dxl_error
+        );
+      }
+
+      if (dxl_comm_result != COMM_SUCCESS) {
+        RCLCPP_INFO(this->get_logger(), "%s", packetHandler->getTxRxResult(dxl_comm_result));
+        response->success = false;
+      } else if (dxl_error != 0) {
+        RCLCPP_INFO(this->get_logger(), "%s", packetHandler->getRxPacketError(dxl_error));
+        response->success = false;
+      } else {
+        if (operating_mode == 0) {
+          // RCLCPP_INFO(this->get_logger(), "Operating mode set to: Current");
+          RCLCPP_INFO(this->get_logger(), "Set [ID: %d] [Goal Current: %d]", dxl_id, operation_target);
+        }
+        if (operating_mode == 3) {
+          // RCLCPP_INFO(this->get_logger(), "Operating mode set to: Position");
+          RCLCPP_INFO(this->get_logger(), "Set [ID: %d] [Goal Position: %d]", dxl_id, operation_target);
+        }
+        response->success = true;
+      }
+    };
+
+  set_operating_mode_service_ = create_service<SetOperatingMode>("set_operating_mode", set_operating_mode_callback);
+}
+
+ReadWriteNode::~ReadWriteNode()
+{
+}
+
+void setupDynamixel(uint8_t dxl_id)
+{
+  // Use Position Control Mode
+  dxl_comm_result = packetHandler->write1ByteTxRx(
+    portHandler,
+    dxl_id,
+    ADDR_OPERATING_MODE,
+    3,
+    &dxl_error
+  );
+
+  if (dxl_comm_result != COMM_SUCCESS) {
+    RCLCPP_ERROR(rclcpp::get_logger("read_write_node"), "Failed to set Position Control Mode.");
+  } else {
+    RCLCPP_INFO(rclcpp::get_logger("read_write_node"), "Succeeded to set Position Control Mode.");
+  }
+
+  // Enable Torque of DYNAMIXEL
+  dxl_comm_result = packetHandler->write1ByteTxRx(
+    portHandler,
+    dxl_id,
+    ADDR_TORQUE_ENABLE,
+    1,
+    &dxl_error
+  );
+
+  if (dxl_comm_result != COMM_SUCCESS) {
+    RCLCPP_ERROR(rclcpp::get_logger("read_write_node"), "Failed to enable torque.");
+  } else {
+    RCLCPP_INFO(rclcpp::get_logger("read_write_node"), "Succeeded to enable torque.");
+  }
+}
+
+// void ReadWriteNode::updateGoalCurrent()
+// {
+//   int new_goal_current;
+//   this->get_parameter("goal_current", new_goal_current);
+//   if (new_goal_current != goal_current)
+//   {
+//     goal_current = new_goal_current;
+//     RCLCPP_INFO(get_logger(), "Goal current updated to: %d", goal_current);
+//     // setTorque(torque_value_);
+//   }
+// }
+
+int main(int argc, char * argv[])
+{
+  portHandler = dynamixel::PortHandler::getPortHandler(DEVICE_NAME);
+  packetHandler = dynamixel::PacketHandler::getPacketHandler(PROTOCOL_VERSION);
+
+  // Open Serial Port
+  dxl_comm_result = portHandler->openPort();
+  if (dxl_comm_result == false) {
+    RCLCPP_ERROR(rclcpp::get_logger("read_write_node"), "Failed to open the port!");
+    return -1;
+  } else {
+    RCLCPP_INFO(rclcpp::get_logger("read_write_node"), "Succeeded to open the port.");
+  }
+
+  // Set the baudrate of the serial port (use DYNAMIXEL Baudrate)
+  dxl_comm_result = portHandler->setBaudRate(BAUDRATE);
+  if (dxl_comm_result == false) {
+    RCLCPP_ERROR(rclcpp::get_logger("read_write_node"), "Failed to set the baudrate!");
+    return -1;
+  } else {
+    RCLCPP_INFO(rclcpp::get_logger("read_write_node"), "Succeeded to set the baudrate.");
+  }
+
+  setupDynamixel(BROADCAST_ID);
+
+  rclcpp::init(argc, argv);
+
+  auto readwritenode = std::make_shared<ReadWriteNode>();
+  rclcpp::spin(readwritenode);
+  rclcpp::shutdown();
+
+  // Disable Torque of DYNAMIXEL
+  packetHandler->write1ByteTxRx(
+    portHandler,
+    BROADCAST_ID,
+    ADDR_TORQUE_ENABLE,
+    0,
+    &dxl_error
+  );
+
+  return 0;
+}

--- a/dynamixel_control/dynamixel_control_msgs/CMakeLists.txt
+++ b/dynamixel_control/dynamixel_control_msgs/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.5)
+project(dynamixel_control_msgs)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+set(msg_files
+  # "msg/SetPosition.msg"
+)
+
+set(srv_files
+  # "srv/GetPosition.srv"
+  "srv/SetOperatingMode.srv"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  ${srv_files}
+  DEPENDENCIES builtin_interfaces
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+ament_package()

--- a/dynamixel_control/dynamixel_control_msgs/package.xml
+++ b/dynamixel_control/dynamixel_control_msgs/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>dynamixel_control_msgs</name>
+  <version>3.7.60</version>
+  <description>ROS2 custom interface for dynamixel gripper controldynamixel_sdk_custom_interfaces</description>
+  <maintainer email="rosettem@oregonstate.edu">marcus</maintainer>
+  <license>BSD-3-Clause</license>
+  <author email="rosettem@oregonstate.edu">marcus</author>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <build_depend>builtin_interfaces</build_depend>
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/dynamixel_control/dynamixel_control_msgs/srv/SetOperatingMode.srv
+++ b/dynamixel_control/dynamixel_control_msgs/srv/SetOperatingMode.srv
@@ -1,0 +1,8 @@
+# Constants
+# Request
+uint8 id
+uint8 operating_mode
+int32 operation_target
+---
+# Response
+bool success


### PR DESCRIPTION
Eliminate the need of including the DynamixelSDK as a sub-repository, and installing the SDK packages explicitly. Then taking our custom mode changing code and placing them in their own package.